### PR TITLE
DEV-3720 - Carousel a11y updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-slider",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/tiny-slider",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1011,7 +1011,7 @@ export var tns = function (options) {
     // == slides ==
     updateSlideStatus();
 
-    var slideText = slideCount === 1 ? 'slide' : 'slides';
+    var slideText = getPages() / slideCount === 1 ? 'slide' : 'slides';
 
     // == live region ==
     outerWrapper.insertAdjacentHTML('afterbegin', '<h3 class="tns-liveregion tns-visually-hidden" aria-live="polite" aria-atomic="true">'+ slideText +' <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</h3>');

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -703,6 +703,9 @@ export var tns = function (options) {
     newContainerClasses += ' tns-' + options.axis;
     container.className += newContainerClasses;
 
+    // set aria-label if not set
+    if(!container.hasAttribute('aria-label')){ container.setAttribute('aria-label', 'Slides') }
+
     // add constrain layer for carousel
     if (carousel) {
       middleWrapper = doc.createElement('div');

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1097,8 +1097,10 @@ export var tns = function (options) {
 
     // == controlsInit ==
     if (hasControls) {
+      var ariaId = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
+
       if (!controlsContainer && (!prevButton || !nextButton)) {
-        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<nav class="tns-controls" aria-label="Carousel"><h3 class="tns-visually-hidden">Carousel Navigation</h3><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></nav>');
+        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<nav class="tns-controls" aria-label="Carousel"><h3 id="carouselNav-'+ ariaId +'" class="tns-visually-hidden">Carousel Navigation</h3><ul aria-labelledby="carouselNav-'+ ariaId +'"><li><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button></li><li><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></li></ul></nav>');
 
         controlsContainer = outerWrapper.querySelector('.tns-controls');
       }

--- a/src/tiny-slider.scss
+++ b/src/tiny-slider.scss
@@ -148,3 +148,8 @@ $perpage: 3;
     }
   }
 }
+
+.tns-controls ul {
+  display: flex;
+  flex-flow: row nowrap;
+}


### PR DESCRIPTION
Carousel a11y updates following James' review of the first round of fixes.

- Wrapped the carousel nav in a `ul` with `aria-labelledby` referencing the `id` on the preceding heading. 
- Fixed slide/slides text