### PR TITLE
DEV-3732 - Remove nav element from tinyslider controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-slider",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/tiny-slider",
-  "version": "2.9.6",
+  "version": "2.9.7",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -1103,7 +1103,7 @@ export var tns = function (options) {
       var ariaId = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
 
       if (!controlsContainer && (!prevButton || !nextButton)) {
-        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<nav class="tns-controls" aria-label="Carousel"><h3 id="carouselNav-'+ ariaId +'" class="tns-visually-hidden">Carousel Navigation</h3><ul aria-labelledby="carouselNav-'+ ariaId +'"><li><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button></li><li><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></li></ul></nav>');
+        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<div class="tns-controls"><h3 id="carouselNav-'+ ariaId +'" class="tns-visually-hidden">Carousel Navigation</h3><ul aria-labelledby="carouselNav-'+ ariaId +'"><li><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button></li><li><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></li></ul></div>');
 
         controlsContainer = outerWrapper.querySelector('.tns-controls');
       }


### PR DESCRIPTION
As discussed, removed `nav` element from carousel controls.