### PR TITLE
DEV-3732 - Make carousel wrapper a labelled region

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-slider",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/tiny-slider",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -253,7 +253,7 @@ export var tns = function (options) {
   }
 
   var horizontal = options.axis === 'horizontal' ? true : false,
-    outerWrapper = doc.createElement('div'),
+    outerWrapper = doc.createElement('section'),
     innerWrapper = doc.createElement('div'),
     middleWrapper,
     container = options.container,
@@ -690,6 +690,7 @@ export var tns = function (options) {
       classInner = 'tns-inner',
       hasGutter = hasOption('gutter');
 
+    outerWrapper.setAttribute('aria-label', 'Carousel')
     outerWrapper.className = classOuter;
     innerWrapper.className = classInner;
     outerWrapper.id = slideId + '-ow';


### PR DESCRIPTION
As per James' feedback - updated the wrapper to a `section` with `aria-label="Carousel"`.