### PR TITLE
Add headingLevel option and remove wrapping section and aria-label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tiny-slider",
-  "version": "2.9.8",
+  "version": "2.9.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/tiny-slider",
-  "version": "2.9.8",
+  "version": "2.9.10",
   "description": "Vanilla javascript slider for all purposes, inspired by Owl Carousel.",
   "main": "dist/tiny-slider.js",
   "types": "src/tiny-slider.d.ts",

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -112,7 +112,8 @@ export var tns = function (options) {
     preventScrollOnTouch: false,
     freezable: true,
     onInit: false,
-    useLocalStorage: true
+    useLocalStorage: true,
+    headingLevel: 3
   }, options || {});
 
   var doc = isServer ? null : document,
@@ -1016,9 +1017,10 @@ export var tns = function (options) {
     updateSlideStatus();
 
     var slideText = getPages() / slideCount === 1 ? 'slide' : 'slides';
+    var slideCountHeadingTag = 'h' + options.headingLevel;
 
     // == live region ==
-    outerWrapper.insertAdjacentHTML('afterbegin', '<h3 class="tns-liveregion tns-visually-hidden" aria-live="polite" aria-atomic="true">'+ slideText +' <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</h3>');
+    outerWrapper.insertAdjacentHTML('afterbegin', '<'+ slideCountHeadingTag +' class="tns-liveregion tns-visually-hidden" aria-live="polite" aria-atomic="true">'+ slideText +' <span class="current">' + getLiveRegionStr() + '</span>  of ' + slideCount + '</'+ slideCountHeadingTag +'>');
     liveregionCurrent = outerWrapper.querySelector('.tns-liveregion .current');
 
     // == autoplayInit ==
@@ -1104,7 +1106,9 @@ export var tns = function (options) {
       var ariaId = Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 5);
 
       if (!controlsContainer && (!prevButton || !nextButton)) {
-        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<div class="tns-controls"><h3 id="carouselNav-'+ ariaId +'" class="tns-visually-hidden">Carousel Navigation</h3><ul aria-labelledby="carouselNav-'+ ariaId +'"><li><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button></li><li><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></li></ul></div>');
+        var controlsHeadingTag = 'h' + options.headingLevel;
+
+        outerWrapper.insertAdjacentHTML(getInsertPosition(options.controlsPosition), '<div class="tns-controls"><'+ controlsHeadingTag +' id="carouselNav-'+ ariaId +'" class="tns-visually-hidden">Carousel Navigation</'+ controlsHeadingTag +'><ul aria-labelledby="carouselNav-'+ ariaId +'"><li><button type="button" data-controls="prev" aria-controls="' + slideId + '" aria-label="Previous Slide">' + controlsText[0] + '</button></li><li><button type="button" data-controls="next" aria-controls="' + slideId + '" aria-label="Next Slide">' + controlsText[1] + '</button></li></ul></div>');
 
         controlsContainer = outerWrapper.querySelector('.tns-controls');
       }

--- a/src/tiny-slider.js
+++ b/src/tiny-slider.js
@@ -254,7 +254,7 @@ export var tns = function (options) {
   }
 
   var horizontal = options.axis === 'horizontal' ? true : false,
-    outerWrapper = doc.createElement('section'),
+    outerWrapper = doc.createElement('div'),
     innerWrapper = doc.createElement('div'),
     middleWrapper,
     container = options.container,
@@ -691,7 +691,6 @@ export var tns = function (options) {
       classInner = 'tns-inner',
       hasGutter = hasOption('gutter');
 
-    outerWrapper.setAttribute('aria-label', 'Carousel')
     outerWrapper.className = classOuter;
     innerWrapper.className = classInner;
     outerWrapper.id = slideId + '-ow';


### PR DESCRIPTION
As discussed on our last a11y call - I've added an option to customize the heading level. It defaults to a `h3` so shouldn't have an impact on any of the existing components.

I've also replaced the wrapping `section` with a `div` and removed the `aria-label` as this should be set in each component.